### PR TITLE
bump package version to fix semver noise

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parse-multipart",
-  "version": "1.0.0004",
+  "version": "1.0.5",
   "description": "A javascript/nodejs multipart/form-data parser which operates on raw data.",
   "main": "multipart.js",
   "author": "Cristian Salazar (christiansalazarh@gmail.com)",


### PR DESCRIPTION
package version of 1.0.0004 is generating false positives for package staleness (as seen by arc.codes) - a version of 1.0.4 would be more standard, but 1.0.5 seems to make sense in terms of a version change.